### PR TITLE
Added a start:watch script, for easier development

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "build:watch": "npm run compile:watch & npm run webpack:store:watch & npm run webpack:admin:watch",
     "start-api": "node src/api/server/index.js",
     "start-store": "node dist/store/server/index.js",
-    "start": "NODE_ENV=production npm run start-api & npm run start-store"
+    "start": "NODE_ENV=production npm run start-api & npm run start-store",
+    "start:watch": "npm run start-api & npm run start-store & npm run build:watch"
   },
   "dependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
Unless I'm missing something, the possibility to run a build process while also starting up the app was missing, soo here it is. 