### PR TITLE
minor fix for handling mongodb uri with options

### DIFF
--- a/config/server.js
+++ b/config/server.js
@@ -1,12 +1,12 @@
 // config used by server side only
-
 const dbHost = process.env.DB_HOST || '127.0.0.1';
 const dbPort = process.env.DB_PORT || 27017;
 const dbName = process.env.DB_NAME || 'shop'
 const dbUser = process.env.DB_USER || '';
 const dbPass = process.env.DB_PASS || '';
 const dbCred = dbUser.length > 0 || dbPass.length > 0 ? `${dbUser}:${dbPass}@` : '';
-const dbUrl = `mongodb://${dbCred}${dbHost}:${dbPort}/${dbName}`;
+
+const dbUrl = process.env.DB_URL || `mongodb://${dbCred}${dbHost}:${dbPort}/${dbName}`;
 
 module.exports = {
   // used by Store (server side)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -50,6 +50,8 @@ DB_PORT=27017 \
 DB_NAME=shop \
 DB_USER=user \
 DB_PASS=password \
+# or SET a DB_URL with mongodb connection string(https://docs.mongodb.com/manual/reference/connection-string/)
+DB_URL=mongodb://db1.example.net:27017,db2.example.net:2500/?replicaSet=test
 npm start
 ```
 

--- a/src/api/server/lib/mongo.js
+++ b/src/api/server/lib/mongo.js
@@ -1,10 +1,11 @@
 const settings = require('./settings');
 const winston = require('winston');
+const url = require('url');
 const MongoClient = require('mongodb').MongoClient;
 
 const mongodbConnection = settings.mongodbServerUrl;
-const lastslashindex = mongodbConnection.lastIndexOf('/');
-const dbName = mongodbConnection.substring(lastslashindex  + 1);
+const mongoPathName = url.parse(mongodbConnection).pathname;
+const dbName = mongoPathName.substring(mongoPathName.lastIndexOf('/') + 1);
 
 const RECONNECT_INTERVAL = 1000;
 const CONNECT_OPTIONS = {


### PR DESCRIPTION
- Added a DB_URL in support for mongodb configuration.
- Fixed error when using mongodb url with options (mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database][?options]])